### PR TITLE
feat: add environment variable support

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,7 @@
+{
+  "trailingComma": "none",
+  "tabWidth": 2,
+  "semi": false,
+  "singleQuote": true,
+  "bracketSpacing": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode"
+}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # @cypress/skip-test [![renovate-app badge][renovate-badge]][renovate-app] [![semantic-release][semantic-image] ][semantic-url] [![CircleCI](https://circleci.com/gh/cypress-io/cypress-skip-test/tree/master.svg?style=svg)](https://circleci.com/gh/cypress-io/cypress-skip-test/tree/master)
+
 > Simple commands to skip a test based on platform, browser or an url
 
 ```js
@@ -137,7 +138,7 @@ onlyOn(S === 'foo', () => {
 You can even run other Cypress commands before deciding to skip or continue
 
 ```js
-it.only('runs if task returns production', () => {
+it('runs if task returns production', () => {
   cy.task('getDbName').then(name => cy.onlyOn(name === 'production'))
   // equivalent
   cy.task('getDbName').then(name => onlyOn(name === 'production'))
@@ -153,7 +154,7 @@ it.only('runs if task returns production', () => {
 You can check the condition against a browser name or an environment yourself.
 
 ```js
-import {isOn} from '@cypress/skip-test'
+import { isOn } from '@cypress/skip-test'
 it('loads users', () => {
   // when running on Windows locally, the backend is not running
   // thus we need to stub XHR requests
@@ -165,6 +166,32 @@ it('loads users', () => {
   cy.get('.user').should('have.length', 10)
 })
 ```
+
+### `ENVIRONMENT`
+
+This module also reads special environment variable `ENVIRONMENT` inside its checks. For example, to only stub network calls on `staging` environment, execute the tests like this:
+
+```shell
+CYPRESS_ENVIRONMENT=staging npx cypress run
+```
+
+Inside the spec file you can write
+
+```js
+import {onlyOn} from '@cypress/skip-test'
+const stubServer = () => {
+  cy.server()
+  cy.route('/api/me', 'fx:me.json')
+  cy.route('/api/permissions', 'fx:permissions.json')
+  // Lots of fixtures ...
+}
+it('works', () => {
+  onlyOn('staging', stubServer)
+  ...
+})
+```
+
+The test `works` will stub network calls when running on `staging`, but will skip calling `stubServer` for other environments.
 
 ### Notes
 

--- a/cypress/integration/callback-spec.js
+++ b/cypress/integration/callback-spec.js
@@ -13,3 +13,21 @@ skipOn('mac', () => {
   // this test will run on every platform but Mac
   it('hides this test on Mac', () => {})
 })
+
+it('runs given function for some environment', () => {
+  Cypress.env('ENVIRONMENT', 'test1')
+  let called
+  onlyOn('test1', () => {
+    called = true
+  })
+  expect(called, 'callback was called').to.be.true
+})
+
+it('does not run given function for other environments', () => {
+  Cypress.env('ENVIRONMENT', 'test1')
+  let called
+  onlyOn('testX', () => {
+    called = true
+  })
+  expect(called, 'callback was NOT called').to.be.undefined
+})

--- a/cypress/integration/is-on-spec.js
+++ b/cypress/integration/is-on-spec.js
@@ -15,3 +15,12 @@ it('returns true for current url', () => {
   expect(isOn(url)).to.be.true
   expect(isOn('foo.com')).to.be.false
 })
+
+it('uses variable ENVIRONMENT', () => {
+  Cypress.env('ENVIRONMENT', 'current test')
+  expect(isOn('current test'), 'matches current ENVIRONMENT').to.be.true
+  expect(isOn('anywhere else'), 'any other value').to.be.false
+
+  Cypress.env('ENVIRONMENT', 'test env 2')
+  expect(isOn('test env 2'), 'matches second ENVIRONMENT').to.be.true
+})

--- a/index.js
+++ b/index.js
@@ -47,9 +47,14 @@ const isOn = name => {
     return Cypress.browser.name === normalizedName
   }
 
+  if (isEnvironment(name)) {
+    return true
+  }
+
   return matchesUrlPart(normalizedName)
 }
 
+// @ts-ignore "cy.state" is not in the "cy" type
 const getMochaContext = () => cy.state('runnable').ctx
 const skip = () => {
   const ctx = getMochaContext()
@@ -58,6 +63,15 @@ const skip = () => {
 
 const isPlatform = name => ['win32', 'darwin', 'linux'].includes(name)
 const isBrowser = name => ['electron', 'chrome', 'firefox'].includes(name)
+/**
+ * You can pass custom environment name when running Cypress
+ * @example
+ * CYPRESS_ENVIRONMENT=staging npx cypress run
+ * @param {string} name Is checked against `ENVIRONMENT` value
+ * @returns {boolean} true if the given argument matches environment string
+ */
+const isEnvironment = name =>
+  Cypress.env('ENVIRONMENT') && Cypress.env('ENVIRONMENT') === name
 
 const matchesUrlPart = normalizedName => {
   // assuming name is part of the url, and the baseUrl should be set

--- a/package-lock.json
+++ b/package-lock.json
@@ -6500,6 +6500,12 @@
         "load-json-file": "^4.0.0"
       }
     },
+    "prettier": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "dev": true
+    },
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "types": "index.d.ts",
   "scripts": {
     "test": "cypress run",
-    "semantic-release": "semantic-release"
+    "semantic-release": "semantic-release",
+    "format": "prettier --write '*.js' 'cypress/**/*.js'"
   },
   "keywords": [
     "cypress",
@@ -17,6 +18,7 @@
   "private": false,
   "devDependencies": {
     "cypress": "3.6.1",
+    "prettier": "1.19.1",
     "semantic-release": "15.13.30"
   },
   "repository": {


### PR DESCRIPTION
- closes #11 

```js
// run tests with 
// CYPRESS_ENVIRONMENT=staging npx cypress run
import {onlyOn} from '@cypress/skip-test'
const stubServer = () => {
  cy.server()
  cy.route('/api/me', 'fx:me.json')
  cy.route('/api/permissions', 'fx:permissions.json')
  // Lots of fixtures ...
}
it('works', () => {
  onlyOn('staging', stubServer)
  ...
})
```