### PR TITLE
feat: add environment checks to skipOn

### DIFF
--- a/cypress/integration/bool-spec.js
+++ b/cypress/integration/bool-spec.js
@@ -27,6 +27,16 @@ it('runs if task returns production', () => {
     .then(onlyOn)
 })
 
+it('runs when on the set environment', () => {
+  Cypress.env('ENVIRONMENT', 'production')
+  onlyOn('production')
+})
+
+it('skips when on the set environment', () => {
+  Cypress.env('ENVIRONMENT', 'production')
+  skipOn('production')
+})
+
 it('skips if task returns production', () => {
   cy.task('getDbName').then(name => skipOn(name === 'production'))
 })

--- a/cypress/integration/callback-spec.js
+++ b/cypress/integration/callback-spec.js
@@ -32,7 +32,7 @@ it('does not run given function for other environments', () => {
   expect(called, 'callback was NOT called').to.be.undefined
 })
 
-it('skips given function for some environment', () => {
+it('does not run given function for some environment', () => {
   Cypress.env('ENVIRONMENT', 'test1')
   let called
   skipOn('test1', () => {

--- a/cypress/integration/callback-spec.js
+++ b/cypress/integration/callback-spec.js
@@ -31,3 +31,21 @@ it('does not run given function for other environments', () => {
   })
   expect(called, 'callback was NOT called').to.be.undefined
 })
+
+it('skips given function for some environment', () => {
+  Cypress.env('ENVIRONMENT', 'test1')
+  let called
+  skipOn('test1', () => {
+    called = true
+  })
+  expect(called, 'callback was called').to.be.undefined
+})
+
+it('runs given function for other environments', () => {
+  Cypress.env('ENVIRONMENT', 'test1')
+  let called
+  skipOn('testX', () => {
+    called = true
+  })
+  expect(called, 'callback was NOT called').to.be.true
+})

--- a/index.js
+++ b/index.js
@@ -78,6 +78,7 @@ const skip = () => {
 const isPlatform = name => ['win32', 'darwin', 'linux'].includes(name)
 const isBrowser = name => ['electron', 'chrome', 'firefox'].includes(name)
 const isHeadedName = name => ['headed', 'headless'].includes(name)
+const isEnvironmentSet = () => Cypress.env('ENVIRONMENT')
 
 const headedMatches = name => {
   if (name === 'headed') {
@@ -163,6 +164,13 @@ const skipOn = (name, cb) => {
       return it(`Skipping test(s) in ${normalizedName} mode`)
     }
 
+    if (isEnvironmentSet()) {
+      if (!isEnvironment(normalizedName)) {
+        return cb()
+      }
+      return it(`Skipping test(s) on ${normalizedName} environment`)
+    }
+
     if (!matchesUrlPart(normalizedName)) {
       return cb()
     }
@@ -181,6 +189,12 @@ const skipOn = (name, cb) => {
         skip()
       }
       return
+    }
+
+    if (isEnvironmentSet()) {
+      if (isEnvironment(normalizedName)) {
+        return skip()
+      }
     }
 
     if (matchesUrlPart(normalizedName)) {

--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ const skip = () => {
 const isPlatform = name => ['win32', 'darwin', 'linux'].includes(name)
 const isBrowser = name => ['electron', 'chrome', 'firefox'].includes(name)
 const isHeadedName = name => ['headed', 'headless'].includes(name)
-const isEnvironmentSet = () => Cypress.env('ENVIRONMENT')
+const isEnvironmentSet = () => typeof Cypress.env('ENVIRONMENT') === 'string' && Cypress.env('ENVIRONMENT')
 
 const headedMatches = name => {
   if (name === 'headed') {


### PR DESCRIPTION
Related issue: https://github.com/cypress-io/cypress-skip-test/issues/41

## What changed?
Added a new condition to check if the ENVIRONMENT variable is set, then either skips or runs the conditions based on whether it matches the expected values.

## How was it tested?
Added some more tests to the spec following the previous logic.