### PR TITLE
Include Definitions for Module Exports in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -24,7 +24,7 @@ declare namespace Cypress {
     })
     ```
     */
-    skipOn(nameOrFlag: string|boolean, cb?: () => void): Chainable<Subject>
+    skipOn(nameOrFlag: string | boolean, cb?: () => void): Chainable<Subject>
 
     /**
     * Only runs the current test if the current browser or platform matches the given name
@@ -44,6 +44,16 @@ declare namespace Cypress {
     })
     ```
     */
-    onlyOn(nameOrFlag: string|boolean, cb?: () => void): Chainable<Subject>
+    onlyOn(nameOrFlag: string | boolean, cb?: () => void): Chainable<Subject>
   }
 }
+
+export const skipOn: (
+  nameOrFlag: string | boolean,
+  cb?: () => void
+) => Cypress.Chainable<any>
+export const onlyOn: (
+  nameOrFlag: string | boolean,
+  cb?: () => void
+) => Cypress.Chainable<any>
+export const isOn: (name: string) => boolean


### PR DESCRIPTION
## Summary
Fixes #91

This change describes the exports from `index.js` in `index.d.ts`, so that TypeScript can properly resolve `import` statements for the module. It also includes running the format command on the `index.d.ts` file.

## Details
I was seeing the "File 'node_modules/@cypress/skip-test/index.d.ts' is not a module." error when trying to add
```typescript
import { onlyOn } from '@cypress/skip-test';
```
to a test file in my project that was written using TypeScript. By modifying `index.d.ts` with the changes in this PR, I was able to resolve the error.

Test file in `cypress/integration/sample_spec.ts`:
```typescript
import { onlyOn, skipOn, isOn } from '@cypress/skip-test'; // This import previous resulted in an error

onlyOn('mac', () => {
  // this callback will only evaluate on Mac
  // thus the tests will be completely hidden from other platforms
  describe('Mac tests', () => {
    it('works', () => {
      Cypress.log({name: 'On Mac?', message: isOn('mac')});
      Cypress.log({name: 'On Windows?', message: isOn('windows')});
    });
  });
});

onlyOn('windows', () => {
  // this callback will only evaluate on Windows
  // thus the tests will be completely hidden from other platforms
  describe('Windows tests', () => {
    it('works', () => {
      Cypress.log({name: 'On Mac?', message: isOn('mac')});
      Cypress.log({name: 'On Windows?', message: isOn('windows')});
    });
  });
});

skipOn('mac', () => {
  // this test will run on every platform but Mac
  it('hides this test on Mac', () => {});
});
```
Test output:
![image](https://user-images.githubusercontent.com/10523985/109063038-acca5a00-76b6-11eb-9329-15543198f88d.png)

My Cypress `tsconfig.json`:
```json
{
  "compilerOptions": {
    "target": "es5",
    "lib": ["es5", "dom"],
    "types": ["cypress"],
  },
  "include": [
    "**/*.ts"
  ]
}
```

My project's root `tsconfig.json`:
```json
{
  "compilerOptions": {
    "target": "es2019",
    "lib": ["es2019", "dom"],
    "module": "commonjs",
    "skipLibCheck": true,
  },
  "include": [
    "**/*.ts"
  ],
}
```