### PR TITLE
feat: allow user to pass sync and async function returning boolean flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,22 @@ onlyOn(S === 'foo', () => {
 })
 ```
 
+Also you can pass sync and async function returning boolean flag.
+
+```js
+// run this test if function returns true
+const fnReturningTrue = () => true
+
+cy.onlyOn(fnReturningTrue())
+```
+
+```js
+// run this test if async function returns true
+const fnReturningPromiseTrue = () => new Promise((resolve) => resolve(true))
+
+cy.onlyOn(fnReturningPromiseTrue())
+```
+
 You can even run other Cypress commands before deciding to skip or continue
 
 ```js

--- a/cypress/integration/function-spec.js
+++ b/cypress/integration/function-spec.js
@@ -1,0 +1,37 @@
+/// <reference types="cypress" />
+import { onlyOn, skipOn } from '../..'
+
+const functionReturningTrue = () => true
+const asyncFunctionReturningTrue = () => new Promise((resolve) => resolve(true))
+
+it('runs on true', () => {
+  onlyOn(functionReturningTrue())
+})
+
+it('skips on true', () => {
+  skipOn(functionReturningTrue())
+})
+
+onlyOn(functionReturningTrue(), () => {
+  it('runs it as callback', () => {})
+})
+
+skipOn(functionReturningTrue(), () => {
+  it('skips this completely', () => {})
+})
+
+it('runs on true', () => {
+  onlyOn(asyncFunctionReturningTrue())
+})
+
+it('skips on true', () => {
+  skipOn(asyncFunctionReturningTrue())
+})
+
+onlyOn(asyncFunctionReturningTrue(), () => {
+  it('runs it as callback', () => {})
+})
+
+skipOn(asyncFunctionReturningTrue(), () => {
+  it('skips this completely', () => {})
+})


### PR DESCRIPTION
This should solve #161.

Passing function which returns true or async function returning true to onlyOn and to skipOn.

